### PR TITLE
Add placeholder image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src="placeholder.png"
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Adds a placeholder image to the top navigation bar when logged in.

![image](https://user-images.githubusercontent.com/10146268/204338614-c395a55c-bbe7-4415-a569-4c5a8f544060.png)

